### PR TITLE
Update README to include postgres issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,22 @@ Common run-ins with Ruby/Rails using Windows 10
   When trying to install/update a Ruby gem via the command line this error is received:  
   ```
   ERROR:  Could not find a valid gem 'rubygems-update' (= 2.6.6), here is why:  
-  Unable to download data from https://rubygems.org/ - 
-  SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: 
+  Unable to download data from https://rubygems.org/ -
+  SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B:
   certificate verify failed (https://api.rubygems.org/specs.4.8.gz)
   ```  
   [Solution](https://github.com/JessBohn/ruby-windows-problems/blob/master/ssl-certificate-error.txt, "SSL Certification Error Solution")
+
+* **Postgresql Authentication Error**
+  When trying to run database commands in Rails apps configured with postgresql instead of sqlite3 I received the following error:
+  ```
+  fe_sendauth: no password supplied
+  Couldn't create database for {"adapter"=>"postgresql", "encoding"=>"unicode", "pool"=>5, "database"=>"GoalMate_development"}
+  rails aborted!
+  PG::ConnectionBad: fe_sendauth: no password supplied
+  bin/rails:9:in `require'
+  bin/rails:9:in `<main>'
+  Tasks: TOP => db:create
+  (See full trace by running task with --trace)
+  ```
+  

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Common run-ins with Ruby/Rails using Windows 10
   [Solution](https://github.com/JessBohn/ruby-windows-problems/blob/master/ssl-certificate-error.txt, "SSL Certification Error Solution")
 
 * **Postgresql Authentication Error**
+  Currently backlogged - used quick, unsecure fix, will return to problem later
   When trying to run database commands in Rails apps configured with postgresql instead of sqlite3 I received the following error:
   ```
   fe_sendauth: no password supplied
@@ -23,4 +24,3 @@ Common run-ins with Ruby/Rails using Windows 10
   Tasks: TOP => db:create
   (See full trace by running task with --trace)
   ```
-  

--- a/postgres-authentication.md
+++ b/postgres-authentication.md
@@ -30,3 +30,6 @@ The error message always contains the 'no password supplied' and hash along with
   authenticated and the databases can be created.
   - The database yaml file was also changed to include the ENVs in their proper spot using code code integration with <%= %>
   - However, when trying to run the db commands it either says no password supplied and that the username and password do not match
+
+  UPDATE:
+    I recently gave up on this method. While everything is still setup for this method and I will return to try and fix it later, I decided to choose a quick, and totally unsecure, fix to my problem. I added the login information directly into the database yaml file. Due to time constraints and needing to work on projects, I had to do this for now.


### PR DESCRIPTION
The previous README only had my the SSL Certification issue listed
on it. Since I came across a new issue and added a separate file for
its resolution, it needed to be added to the list that is displayed
on the main page of the repo. Therefore I added the postgres
authentication error to the page. The listing contains a brief
overview of the problems as well as the error message received when
performing the process. The message is displayed using a code block.